### PR TITLE
UNP-8189: bump Reality server to Xray-core v26.6.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+### [Unreleased] - 2026-07-01
+- UNP-8189: bump Reality server Xray-core from v1.8.4 to v26.6.22 (both Ubuntu 20.04 and 24.04 install paths) to match the VPN 2.0 client; drop `minClientVer` from `reality_config.json` so legacy clients can still connect while we evaluate a client-update strategy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ### [Unreleased] - 2026-07-01
 - UNP-8189: bump Reality server Xray-core from v1.8.4 to v26.6.22 (both Ubuntu 20.04 and 24.04 install paths) to match the VPN 2.0 client; drop `minClientVer` from `reality_config.json` so legacy clients can still connect while we evaluate a client-update strategy.
+- UNP-8189: parse the new `xray x25519` output format (`PrivateKey:` / `Password (PublicKey):`) in `install_reality.sh` / `install_reality-2404.sh`. v26.6.22 changed the layout, which left `privateKey` empty (xray failed to start) and the client `pbk` empty; extract by label instead of fixed field position.

--- a/install_reality-2404.sh
+++ b/install_reality-2404.sh
@@ -46,9 +46,9 @@ fi
 X25519=$(./xray x25519)
 echo "X25519:"
 echo "$X25519"
-X_PRIVATE_KEY=$(echo "$X25519" | head -1 | cut -d " " -f 3)
+X_PRIVATE_KEY=$(echo "$X25519" | awk '/PrivateKey:/ {print $2}')
 echo "X_PRIVATE_KEY: $X_PRIVATE_KEY"
-X_PUBLIC_KEY=$(echo "$X25519" | tail -1 | cut -d " " -f 3)
+X_PUBLIC_KEY=$(echo "$X25519" | awk '/\(PublicKey\)/ {print $NF}')
 RABBIT_URL="amqp://${RABBIT_DATABASE_USERNAME}:${RABBIT_DATABASE_PASSWORD}@${RABBIT_HOST}:${RABBIT_PORT}"
 echo "Rabbit url: ${RABBIT_URL}"
 uuid=$(./xray uuid -i Secret)

--- a/install_reality-2404.sh
+++ b/install_reality-2404.sh
@@ -31,7 +31,7 @@ mkdir /opt/xray
 cd /opt/xray
 sudo apt-get update -o DPkg::Lock::Timeout=-1
 sudo apt-get install -o DPkg::Lock::Timeout=-1 unzip
-wget https://github.com/XTLS/Xray-core/releases/download/v1.8.4/Xray-linux-64.zip
+wget https://github.com/XTLS/Xray-core/releases/download/v26.6.22/Xray-linux-64.zip
 unzip Xray-linux-64.zip
 rm -f Xray-linux-64.zip
 if [ -z "$REALITY_EXTERNAL_HOST" ]; then

--- a/install_reality.sh
+++ b/install_reality.sh
@@ -46,9 +46,9 @@ fi
 X25519=$(./xray x25519)
 echo "X25519:"
 echo "$X25519"
-X_PRIVATE_KEY=$(echo "$X25519" | head -1 | cut -d " " -f 3)
+X_PRIVATE_KEY=$(echo "$X25519" | awk '/PrivateKey:/ {print $2}')
 echo "X_PRIVATE_KEY: $X_PRIVATE_KEY"
-X_PUBLIC_KEY=$(echo "$X25519" | tail -1 | cut -d " " -f 3)
+X_PUBLIC_KEY=$(echo "$X25519" | awk '/\(PublicKey\)/ {print $NF}')
 RABBIT_URL="amqp://${RABBIT_DATABASE_USERNAME}:${RABBIT_DATABASE_PASSWORD}@${RABBIT_HOST}:${RABBIT_PORT}"
 echo "Rabbit url: ${RABBIT_URL}"
 uuid=$(./xray uuid -i Secret)

--- a/install_reality.sh
+++ b/install_reality.sh
@@ -31,7 +31,7 @@ mkdir /opt/xray
 cd /opt/xray
 sudo apt-get update -o DPkg::Lock::Timeout=-1
 sudo apt-get install -o DPkg::Lock::Timeout=-1 unzip
-wget https://github.com/XTLS/Xray-core/releases/download/v1.8.4/Xray-linux-64.zip
+wget https://github.com/XTLS/Xray-core/releases/download/v26.6.22/Xray-linux-64.zip
 unzip Xray-linux-64.zip
 rm -f Xray-linux-64.zip
 if [ -z "$REALITY_EXTERNAL_HOST" ]; then

--- a/reality_config.json
+++ b/reality_config.json
@@ -53,7 +53,6 @@
             "REALITY_EXTERNAL_HOST"
           ],
           "privateKey": "REALITY_PRIVATE_KEY",
-          "minClientVer": "1.8.0",
           "maxClientVer": "",
           "maxTimeDiff": 0,
           "shortIds": REALITY_SHORT_IDS


### PR DESCRIPTION
## Summary
Part of **VPN 2.0 Revive** ([UNP-8135](https://unplugged-systems.atlassian.net/browse/UNP-8135)). The VPN 2.0 client now links Xray-core **v26.6.22** (via AndroidLibXrayLite / UNP-8155), but this provisioning script still installs **v1.8.4** (Aug 2023). The ~3-year Reality/Xray protocol gap breaks the Reality handshake, so the new client cannot connect to servers built by this script.

Jira: [UNP-8189](https://unplugged-systems.atlassian.net/browse/UNP-8189)

## Changes
- `install_reality.sh` / `install_reality-2404.sh`: bump Xray-core download `v1.8.4` → `v26.6.22` (verified the release tag + `Xray-linux-64.zip` asset exist).
- `reality_config.json`: **drop** `minClientVer` (`"1.8.0"`). The new CalVer scheme makes the old semver gate meaningless, and dropping it lets **legacy clients keep connecting** so we can measure backward compatibility before committing to a production rollout / client-update strategy.

## Staging test steps
- [ ] Point staging's `VPN_SCRIPT_BRANCH` Vault key at `UNP-8189-bump-reality-server-to-xray-v26-6-22`.
- [ ] Provision a fresh staging VPN server; confirm `/opt/xray/xray version` reports v26.6.22 and the `xray` service is active.
- [ ] Connect with the **new VPN 2.0 client** over Reality — handshake + traffic.
- [ ] Connect with an **old/legacy client** over Reality — confirm whether it still works with `minClientVer` dropped (this informs whether we need a forced client-update strategy before production).

> ⚠️ Do **not** merge to `main` (production) until the legacy-client compatibility result is reviewed and an update strategy is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UNP-8135]: https://unplugged-systems.atlassian.net/browse/UNP-8135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UNP-8189]: https://unplugged-systems.atlassian.net/browse/UNP-8189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ